### PR TITLE
Don't send ImageID

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn container_into_pb(kube: &KubeState, c: Container) -> pb::WorkloadInstance {
                 Some(dt) => Some(dt_to_timestamp(dt)),
                 None => Some(TIMESTAMP_INFINITY),
             },
-            image_id: clean_image_id(&c.image_id).to_string(),
+            image_id: String::new(), //clean_image_id(&c.image_id).to_string(),
             image: Some(pb::Image {
                 kind: Some(pb::image::Kind::Docker(pb::DockerImage { tag: c.image })),
             }),
@@ -181,7 +181,7 @@ fn container_into_pb(kube: &KubeState, c: Container) -> pb::WorkloadInstance {
                 Some(dt) => Some(dt_to_timestamp(dt)),
                 None => Some(TIMESTAMP_INFINITY),
             },
-            image_id: clean_image_id(&c.image_id).to_string(),
+            image_id: String::new(), //clean_image_id(&c.image_id).to_string(),
             image: None,
             machine_id,
         }


### PR DESCRIPTION
Since the kube API does not reliably return the image ID but rather the RepoDigest (at least for containerd), do not send it to avoid overwriting a good value sent by the node agent.