### PR TITLE
Use test branch for SBOM action

### DIFF
--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -40,7 +40,7 @@ jobs:
       - run: unzip artifacts.zip
 
       - name: Upload SBOM to EdgeBit
-        uses: edgebitio/edgebit-build@main
+        uses: edgebitio/edgebit-build@rs/workflow_run
         with:
           edgebit-url: https://edgebit.edgebit.io
           token: ${{ secrets.EDGEBIT_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR tests out new logic to use the workflow_run event or the PR number to fetch the base SHA. It pulls from https://github.com/edgebitio/edgebit-build/pull/7.

The intended result is to get the diff style bot comment not the single commit "view sbom" comment that you see below.