### PR TITLE
Use ImageID instead of a Digest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ matrix.runs-on == 'buildjet-4vcpu-ubuntu-2204' }}
         uses: eyakubovich/sbom-action@ey/add-config-input
         with:
-          image: ${{ steps.build.outputs.digest }}
+          image: ${{ steps.build.outputs.imageid }}
           artifact-name: sbom.spdx.json
           upload-artifact: true
           config: .github/edgebit/build-syft.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ matrix.arch == 'amd64' }}
         uses: eyakubovich/sbom-action@ey/add-config-input
         with:
-          image: ${{ steps.build.outputs.digest }}
+          image: ${{ steps.build.outputs.imageid }}
           artifact-name: sbom.spdx.json
           upload-artifact: true
           config: .github/edgebit/build-syft.yaml


### PR DESCRIPTION
If not pushing to the registry, ImageID and the Digest are the same. However they're different if you push.