### PR TITLE
Add image-tag to SBOM metadata

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,11 +19,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Generate Image Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            public.ecr.aws/edgebit/cluster-agent
+          tags: |
+            type=ref,event=pr,suffix=-${{ matrix.arch }}
+          flavor: |
+            latest=false
+
       - id: build
         name: Building agent
         uses: docker/build-push-action@v3
         with:
-          push: false
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Generate SBOM from the container
         if: ${{ matrix.runs-on == 'buildjet-4vcpu-ubuntu-2204' }}
@@ -40,6 +52,7 @@ jobs:
           cat > /tmp/metadata.json <<EOF
             {
               "image-id": "${{ steps.build.outputs.imageid }}",
+              "image-tag": "${{ steps.meta.outputs.tags }}",
               "pr-number": "${{ github.event.number }}",
               "tags": "${{ github.ref == 'refs/heads/main' && 'latest' || '' }}"
             }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   build-binaries:
+    permissions:
+      id-token: write # for AWS OIDC
+
     strategy:
       matrix:
         include:
@@ -22,6 +25,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Authenticate to AWS
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::970625735569:role/GitHubActionsECRPush
+
+      - name: Configure AWS Docker Auth
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: true
+          registry-type: public
 
       - name: Generate Image Metadata
         id: meta

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,13 @@ jobs:
   build-binaries:
     strategy:
       matrix:
-        runs-on: [buildjet-4vcpu-ubuntu-2204, buildjet-4vcpu-ubuntu-2204-arm]
+        include:
+          - runner: buildjet-4vcpu-ubuntu-2204
+            arch: amd64
+          - runner: buildjet-4vcpu-ubuntu-2204-arm
+            arch: arm64
 
-    runs-on: ${{matrix.runs-on}}
+    runs-on: ${{matrix.runner}}
 
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +42,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Generate SBOM from the container
-        if: ${{ matrix.runs-on == 'buildjet-4vcpu-ubuntu-2204' }}
+        if: ${{ matrix.arch == 'amd64' }}
         uses: anchore/sbom-action@v0
         with:
           image: ${{ steps.build.outputs.imageid }}
@@ -47,7 +51,7 @@ jobs:
           config: .github/edgebit/build-syft.yaml
 
       - name: Save metadata to an artifact
-        if: ${{ matrix.runs-on == 'buildjet-4vcpu-ubuntu-2204' }}
+        if: ${{ matrix.arch == 'amd64' }}
         run: |
           cat > /tmp/metadata.json <<EOF
             {
@@ -59,7 +63,7 @@ jobs:
           EOF
 
       - uses: actions/upload-artifact@v3
-        if: ${{ matrix.runs-on == 'buildjet-4vcpu-ubuntu-2204' }}
+        if: ${{ matrix.arch == 'amd64' }}
         with:
           name: metadata.json
           path: /tmp/metadata.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Generate SBOM from the container
         if: ${{ matrix.runs-on == 'buildjet-4vcpu-ubuntu-2204' }}
-        uses: eyakubovich/sbom-action@ey/add-config-input
+        uses: anchore/sbom-action@v0
         with:
           image: ${{ steps.build.outputs.imageid }}
           artifact-name: sbom.spdx.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write  # for sigstore OIDC
-      contents: write  # for pushing the signed tag
+      id-token: write # for sigstore OIDC
+      contents: write # for pushing the signed tag
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write  # For creating a draft release
+      contents: write # For creating a draft release
 
     steps:
       - name: Creating a draft release
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{matrix.runner}}
 
     permissions:
-      id-token: write  # For AWS OIDC
+      id-token: write # For AWS OIDC
 
     steps:
       - uses: actions/checkout@v3
@@ -95,7 +95,7 @@ jobs:
       - name: Generate SBOM from the container
         id: sbom
         if: ${{ matrix.arch == 'amd64' }}
-        uses: anchore/sbom-action@main
+        uses: anchore/sbom-action@v0
         with:
           image: ${{ steps.build.outputs.imageid }}
           output-file: /tmp/sbom.spdx.json
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write  # For AWS OIDC
+      id-token: write # For AWS OIDC
 
     steps:
       - name: Authenticate to AWS
@@ -156,4 +156,3 @@ jobs:
             $tags \
             public.ecr.aws/edgebit/cluster-agent:${{ steps.meta.outputs.version}}-amd64 \
             public.ecr.aws/edgebit/cluster-agent:${{ steps.meta.outputs.version}}-arm64
-


### PR DESCRIPTION
Adds missing SBOM image tag metadata similar to https://github.com/edgebitio/edgebit-agent/pull/78

Switches back to using the upstream `anchore/sbom-action@v0` action instead of the `eyakubovich/sbom-action@ey/add-config-input` fork now that the config input changes have landed.

Constructs container metadata and job matrix similar to `edgebit-agent` and now pushes PR images by default