### PR TITLE
Use the new style cataloger spec

### DIFF
--- a/.github/edgebit/build-syft.yaml
+++ b/.github/edgebit/build-syft.yaml
@@ -1,8 +1,4 @@
 check-for-app-update: false
 
-catalogers:
-  - apk
-  - go-module-binary
-  - go-mod-file
-  - rust-cargo-lock
-  - sbom
+select-catalogers:
+  - "+rust-cargo-lock-cataloger"


### PR DESCRIPTION
Recent Syft changed how the catalogers are specified. Instead of a single "catalogers:" key, it uses
"default-catalogers:" and "select-catalogers:" keys.

Since this is for scanning an image, the "apk" cataloger is there by default but the "Cargo.lock" one is not and needs to be manually added.